### PR TITLE
don't escape null argument

### DIFF
--- a/src/grex.js
+++ b/src/grex.js
@@ -102,6 +102,9 @@
     }
 
     function parseArgs(val) {
+        if(val === null) {
+            return 'null';
+        }
         //check to see if the arg is referencing the graph ie. g.v(1)
         if(isObject(val) && val.hasOwnProperty('params') && isGraphReference(val.params)){
             return val.params.toString();


### PR DESCRIPTION
I've added a special case in order to prevent grex from escaping null arguments. This allows queries such as `db.V().has('name', 'T.neq', null)`.

As as note, I thought it made sense to support the JavaScript null object as opposed to a 'null' string to prevent any ambiguities. Although, it's a bit odd that it doesn't follow the convention of the other Java values (e.g. T.eq).
