### PR TITLE
Handle nested objects in GremlinFunction#stringifyArgument

### DIFF
--- a/src/functions/function.js
+++ b/src/functions/function.js
@@ -78,6 +78,10 @@ module.exports = (function() {
         acc += ',';
     }
 
+    if(typeof val === 'undefined') {
+      val = null;
+    }
+
     var newVal;
     if(_.isObject(val)) {
         newVal = '[' +  _.reduce(val, stringify, '') + ']' ;

--- a/test/gremlinfunction.js
+++ b/test/gremlinfunction.js
@@ -17,5 +17,12 @@ describe('GremlinFunction', function() {
       func.stringifyArgument({one: {left: '{', right: '}'}})
         .should.equal('["one":["left":"{","right":"}"]]');
     });
+
+    it('should handle undefined and null values as null', function () {
+      var func = new GremlinFunction('testFunction');
+
+      func.stringifyArgument({'null': null, 'undefined': undefined})
+        .should.equal('["null":null,"undefined":null]');
+    });
   });
 });


### PR DESCRIPTION
GremlinFunction#stringifyArguments converts objects to maps by just replacing the first open and the first close curly braces with the equivalent square brackets when converting to Groovy. This doesn't work for nested objects, and for values with close curly braces.

For example:

Before:

```
> g.addVertex({name: {first: 'John', last: 'Doe'}}).methods;
[ '.addVertex(["name":{"first":"John","last":"Doe"]})' ]
> g.addVertex({curlyLeft: '{', curlyRight: '}'}).methods;
[ '.addVertex(["curlyLeft":"{","curlyRight":"]"})' ]
```

After:

```
> g.addVertex({name: {first: 'John', last: 'Doe'}}).methods;
[ '.addVertex(["name":["first":"John","last":"Doe"]])' ]
> g.addVertex({curlyLeft: '{', curlyRight: '}'}).methods;
[ '.addVertex(["curlyLeft":"{","curlyRight":"}"])' ]
```
